### PR TITLE
Fixing compatiblity with Requests>=1.0.0

### DIFF
--- a/warc/warc.py
+++ b/warc/warc.py
@@ -237,7 +237,7 @@ class WARCRecord(object):
         
         headers = {
             "WARC-Type": "response",
-            "WARC-Target-URI": response.request.full_url.encode('utf-8')
+            "WARC-Target-URI": response.request.url.encode('utf-8')
         }
         return WARCRecord(payload=payload, headers=headers)
 


### PR DESCRIPTION
Fixes issue #13 by stripping out 'full_' from 'full_url' when writing "WARC-Target-URI"-header
