### PR TITLE
Bugfix, sets license in the package classifiers to GPLv2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
+        'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
     ],


### PR DESCRIPTION
License fix was incomplete, the classifiers list of the package still said 'BSD'.
