### PR TITLE
Fix WARC writing bug

### DIFF
--- a/warc/utils.py
+++ b/warc/utils.py
@@ -94,3 +94,6 @@ class FilePart:
         while line:
             yield line
             line = self.readline()
+
+    def __len__(self):
+        return self.length

--- a/warc/utils.py
+++ b/warc/utils.py
@@ -94,6 +94,3 @@ class FilePart:
         while line:
             yield line
             line = self.readline()
-
-    def __len__(self):
-        return self.length

--- a/warc/warc.py
+++ b/warc/warc.py
@@ -158,7 +158,7 @@ class WARCRecord(object):
                 
     def write_to(self, f):
         self.header.write_to(f)
-        f.write(self.payload)
+        f.write(self.payload.buf)
         f.write("\r\n")
         f.write("\r\n")
         f.flush()


### PR DESCRIPTION
I had this issue writing a WARC record to a file:

``` shell
[jeff@lamarzocco warcs]$ ./cleanwarc.py  in.warc.gz filtered.warc.gz
Traceback (most recent call last):
  File "./cleanwarc.py", line 86, in <module>
    main()
  File "./cleanwarc.py", line 82, in main
    filter_warc(args.infile, args.outfile)
  File "./cleanwarc.py", line 61, in filter_warc
    output_warc.write_record(record)
  File "/usr/lib/python2.7/site-packages/warc/warc.py", line 268, in write_record
    warc_record.write_to(self.fileobj)
  File "/usr/lib/python2.7/site-packages/warc/warc.py", line 161, in write_to
    f.write(self.payload)
  File "/usr/lib/python2.7/site-packages/warc/gzip2.py", line 71, in write
    BaseGzipFile.write(self, data)
  File "/usr/lib/python2.7/gzip.py", line 240, in write
    if len(data) > 0:
AttributeError: FilePart instance has no attribute '__len__'
```

I added a `__len__` function to FilePart to fix this, but got this error:

``` shell
Traceback (most recent call last):
  File "./cleanwarc.py", line 90, in <module>
    main()
  File "./cleanwarc.py", line 86, in main
    filter_warc(args.infile, args.outfile)
  File "./cleanwarc.py", line 65, in filter_warc
    output_warc.write_record(record)
  File "/usr/lib/python2.7/site-packages/warc/warc.py", line 268, in write_record
    warc_record.write_to(self.fileobj)
  File "/usr/lib/python2.7/site-packages/warc/warc.py", line 161, in write_to
    f.write(self.payload)
  File "/usr/lib/python2.7/site-packages/warc/gzip2.py", line 71, in write
    BaseGzipFile.write(self, data)
  File "/usr/lib/python2.7/gzip.py", line 241, in write
    self.fileobj.write(self.compress.compress(data))
TypeError: must be string or read-only buffer, not instance
```

This PR fixes both issues by passing the `buf` attribute of the FilePart (rather than the whole FilePart) to gzip.
