### PR TITLE
Changes to make library compatible with Python3.

### DIFF
--- a/warc/tests/test_common.py
+++ b/warc/tests/test_common.py
@@ -38,7 +38,3 @@ def test_sample_data():
     expected = """http://www.killerjo.net:80/robots.txt 211.111.217.29 20110804181142       39
 SSH-2.0-OpenSSH_5.3p1 Debian-3ubuntu3\r\n\n"""
     assert record == expected
-
-
-    
-

--- a/warc/tests/test_utils.py
+++ b/warc/tests/test_utils.py
@@ -1,5 +1,8 @@
 from ..utils import FilePart, CaseInsensitiveDict
-from cStringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 class TestCaseInsensitiveDict:
     def test_all(self):

--- a/warc/tests/test_warc.py
+++ b/warc/tests/test_warc.py
@@ -1,6 +1,9 @@
 from ..warc import WARCReader, WARCHeader, WARCRecord, WARCFile
 
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 class TestWARCHeader:
     def test_attrs(self):
@@ -99,13 +102,14 @@ class TestWarcFile:
 
     def test_write_gz(self):
         """Test writing multiple member gzip file."""
-        buffer = StringIO()
-        f = WARCFile(fileobj=buffer, mode="w", compress=True)
+        from io import BytesIO
+        buffer = BytesIO()
+        f = WARCFile(fileobj=buffer, mode="wb", compress=True)
         for i in range(10):
-            record = WARCRecord(payload="hello %d" % i)
+            record = WARCRecord(payload=b"hello %d" % i)
             f.write_record(record)
 
-        GZIP_MAGIC_NUMBER = '\037\213'
+        GZIP_MAGIC_NUMBER = b'\037\213'
         assert buffer.getvalue().count(GZIP_MAGIC_NUMBER) == 10
 
     def test_long_header(self):

--- a/warc/utils.py
+++ b/warc/utils.py
@@ -7,7 +7,10 @@ This file is part of warc
 :copyright: (c) 2012 Internet Archive
 """
 
-from UserDict import DictMixin
+try:
+    from UserDict import DictMixin
+except ImportError:
+    from collections import MutableMapping as DictMixin
 
 class CaseInsensitiveDict(DictMixin):
     """Almost like a dictionary, but keys are case-insensitive.
@@ -23,9 +26,9 @@ class CaseInsensitiveDict(DictMixin):
         >>> d.keys()
         ["foo", "bar"]
     """
-    def __init__(self, mapping=None, **kwargs):
+    def __init__(self, *args, **kwargs):
         self._d = {}
-        self.update(mapping, **kwargs)
+        self.update(*args, **kwargs)
         
     def __setitem__(self, name, value):
         self._d[name.lower()] = value
@@ -38,7 +41,14 @@ class CaseInsensitiveDict(DictMixin):
         
     def __eq__(self, other):
         return isinstance(other, CaseInsensitiveDict) and other._d == self._d
-        
+
+    def __len__(self):
+        return len(self._d)
+
+    def __iter__(self):
+        for i in self._d:
+            yield i
+
     def keys(self):
         return self._d.keys()
 


### PR DESCRIPTION
Hello,

I have been working on to make the library work with Py3. Changes include:

* Fixing StringIO import and its usage.
* Fixing obsolete __builitin__ import.
* Fixed obsolete DictMixin import for base class and corresponding changes in arguments.
* Specific cases of handling str and bytes type to make sure things are working.
* There are changes in GZipFile, fixed read_member function of GzipFile to return _buffer element for py3.

Existing tests are working fine with this PR but I think they need to be extended to make sure handling of bytes and str types are working in all possible scenarios. Do let me know your comments and reviews and I will fix and update the PR accordingly.
